### PR TITLE
Fix link color in posts

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -662,3 +662,7 @@ code {
 pre code {
   white-space: pre;
 }
+
+div.post_container a {
+  color: $color_link;
+}


### PR DESCRIPTION
Example:

![image](https://user-images.githubusercontent.com/3905501/27235854-dcd26666-5298-11e7-9e1b-633b78692d79.png)